### PR TITLE
Add ssh cloning

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"onView:jbspaceProjects"
 	],
 
-	
+
 	"contributes": {
 		"commands": [
 			{
@@ -72,14 +72,14 @@
 					"dark": "media/icons/plus-solid.svg"
 				}
 			},
-			{
-				"command": "jbspaceProjects.cloneRepository",
-				"title": "Clone Repository",
-				"icon": {
-					"light": "media/icons/cloud-download-alt-solid.svg",
-					"dark": "media/icons/cloud-download-alt-solid.svg"
-				}
-			},
+            {
+            "command": "jbspaceProjects.cloneRepositoryWithHttp",
+            "title": "Clone using Http"
+          },
+            {
+              "command": "jbspaceProjects.cloneRepositoryWithSsh",
+              "title": "Clone using SSH"
+            },
 			{
 				"command": "jbspaceProjects.deleteRepository",
 				"title": "Delete Repository",
@@ -161,6 +161,13 @@
 				}
 			}
 		],
+		"submenus": [
+			{
+				"id": "git.clone.submenu",
+				"label": "Clone Repository",
+				"icon": "media/icons/cloud-download-alt-solid.svg"
+			}
+		],
 		"menus": {
 			"view/title": [
 				{
@@ -190,11 +197,11 @@
 					"when": "view == jbspaceProjects && viewItem == repositories",
 					"group": "inline"
 				},
-				{
-					"command": "jbspaceProjects.cloneRepository",
-					"when": "view == jbspaceProjects && viewItem == repository",
-					"group": "inline"
-				},
+                {
+                "submenu": "git.clone.submenu",
+                "when": "view == jbspaceProjects && viewItem == repository",
+                "group": "inline"
+              },
 				{
 					"command": "jbspaceProjects.deleteRepository",
 					"when": "view == jbspaceProjects && viewItem == repository",
@@ -245,8 +252,21 @@
 					"when": "view == jbspaceTodos && viewItem == todo-closed",
 					"group": "inline"
 				}
+			],
+			"git.clone.submenu": [
+				{
+					"command": "jbspaceProjects.cloneRepositoryWithHttp",
+					"when": "view == jbspaceProjects && viewItem == repository",
+					"group": "inline"
+				},
+				{
+					"command": "jbspaceProjects.cloneRepositoryWithSsh",
+					"when": "view == jbspaceProjects && viewItem == repository",
+					"group": "inline"
+				}
 			]
 		},
+
 		"viewsWelcome": [
 			{
 				"view": "jbspaceWelcome",

--- a/src/api/models/RepositoryUrls.ts
+++ b/src/api/models/RepositoryUrls.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type RepositoryUrls = {
+    httpUrl: string | null;
+    sshHost: string | null;
+    sshUrl: string | null;
+}

--- a/src/api/services/Service.ts
+++ b/src/api/services/Service.ts
@@ -172,6 +172,7 @@ import type { VcsHostingPassword } from '../models/VcsHostingPassword';
 import type { Weekday } from '../models/Weekday';
 import type { WorkingDaysSpec } from '../models/WorkingDaysSpec';
 import { request as __request } from '../core/request';
+import {RepositoryUrls} from "../models/RepositoryUrls";
 
 export class Service {
 
@@ -11596,6 +11597,29 @@ export class Service {
                 '$fields': fields,
             },
         });
+        return result.body;
+    }
+
+    /**
+     * Get repository url
+     * @param projectId
+     * @param repositoryName
+     * @result RepositoryUrls
+     * @result any Error
+     * @throws ApiError
+     */
+    public static async getService163(
+        projectId: string,
+        repositoryName: string
+    ): Promise<RepositoryUrls | {
+        error: string,
+        error_description: string
+    }> {
+        const result = await __request({
+            method: 'GET',
+            path: `/projects/${projectId}/repositories/${repositoryName}/url`,
+        });
+
         return result.body;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,57 +25,42 @@ export function activate(context: vscode.ExtensionContext) {
 		todosProvider.refresh();
 	}
 
-    const registerCommand = (name: string, fn: any, ...extraArgs: any[]) => {
-        console.log(`extra args: ${extraArgs}`)
-        return vscode.commands.registerCommand(
-            name,
-            (args) => fn(args, ...extraArgs)
-        )
-    }
+	const registerCommand = (name: string, fn: any, ...extraArgs: any[]) =>
+		vscode.commands.registerCommand(name, (args) => fn(args, ...extraArgs))
 
+	const vsCommands = [
+		registerCommand('jbspace.setCredentials', () => projectsCommands.setToken(context).then(() => {
+			projectsProvider.refresh();
+			todosProvider.refresh();
+		})),
 
-	const setCredentialsCmd = vscode.commands.registerCommand('jbspace.setCredentials', () => projectsCommands.setToken(context).then(() => {
-		projectsProvider.refresh();
-		todosProvider.refresh();
-	}));
+		// Project commands
+		registerCommand('jbspaceProjects.refreshProjects', projectsProvider.refresh),
+		registerCommand('jbspaceProjects.createProject', projectsCommands.createProject),
 
-	context.subscriptions.push(setCredentialsCmd);
+		// Repository commands
+		registerCommand('jbspaceProjects.createRepository', projectsCommands.createRepository),
+		registerCommand('jbspaceProjects.cloneRepositoryWithHttp', projectsCommands.cloneRepository),
+		registerCommand('jbspaceProjects.cloneRepositoryWithSsh', projectsCommands.cloneRepository, true),
+		registerCommand('jbspaceProjects.deleteRepository', projectsCommands.deleteRepository),
 
-	const refreshProjectsCmd = vscode.commands.registerCommand('jbspaceProjects.refreshProjects', () => projectsProvider.refresh());
-	const createProjectCmd = vscode.commands.registerCommand('jbspaceProjects.createProject', (args) => projectsCommands.createProject(args));
-	context.subscriptions.push(refreshProjectsCmd);
-	context.subscriptions.push(createProjectCmd);
+		// Issues commands
+		registerCommand('jbspaceProjects.createIssue', projectsCommands.createIssue),
+		registerCommand('jbspaceProjects.markIssueResolved', projectsCommands.markIssueResolved, true),
+		registerCommand('jbspaceProjects.markIssueUnresolved', projectsCommands.markIssueResolved, false),
+		registerCommand('jbspaceProjects.deleteIssue', projectsCommands.deleteIssue),
 
-	const createRepoCmd = vscode.commands.registerCommand('jbspaceProjects.createRepository', (args) => projectsCommands.createRepository(args));
-	const cloneRepoWithHttpCmd = vscode.commands.registerCommand('jbspaceProjects.cloneRepositoryWithHttp', (args) => projectsCommands.cloneRepository(args));
-	const cloneRepoWithSshCmd = vscode.commands.registerCommand('jbspaceProjects.cloneRepositoryWithSsh', (args) => projectsCommands.cloneRepository(args, true));
-	const deleteRepoCmd = vscode.commands.registerCommand('jbspaceProjects.deleteRepository', (args) => projectsCommands.deleteRepository(args));
-	context.subscriptions.push(createRepoCmd);
-	context.subscriptions.push(cloneRepoWithHttpCmd);
-	context.subscriptions.push(cloneRepoWithSshCmd);
-	context.subscriptions.push(deleteRepoCmd);
+		// Todos commands
+		registerCommand('jbspaceTodos.refreshTodos', todosProvider.refresh),
+		registerCommand('jbspaceTodos.createTodo', todosCommands.createTodo),
+		registerCommand('jbspaceTodos.deleteTodo', todosCommands.deleteTodo),
+		registerCommand('jbspaceTodos.markTodoClosed', todosCommands.markTodoClosed),
+		registerCommand('jbspaceTodos.markTodoOpen', todosCommands.markTodoOpen),
+	];
 
-	const createIssueCmd = vscode.commands.registerCommand('jbspaceProjects.createIssue', (args) => projectsCommands.createIssue(args));
-	const resolveIssueCmd = vscode.commands.registerCommand('jbspaceProjects.markIssueResolved', (args) => projectsCommands.markIssueResolved(args, true));
-	const unresolveIssueCmd = vscode.commands.registerCommand('jbspaceProjects.markIssueUnresolved', (args) => projectsCommands.markIssueResolved(args, false));
-	const deleteIssueCmd = vscode.commands.registerCommand('jbspaceProjects.deleteIssue', (args) => projectsCommands.deleteIssue(args));
-	context.subscriptions.push(createIssueCmd);
-	context.subscriptions.push(resolveIssueCmd);
-	context.subscriptions.push(unresolveIssueCmd);
-	context.subscriptions.push(deleteIssueCmd);
-
-
-	const refreshTodosCmd = vscode.commands.registerCommand('jbspaceTodos.refreshTodos', () => todosProvider.refresh());
-	const createTodoCmd = vscode.commands.registerCommand('jbspaceTodos.createTodo', (args) => todosCommands.createTodo(args));
-	context.subscriptions.push(refreshTodosCmd);
-	context.subscriptions.push(createTodoCmd);
-
-	const deleteTodoCmd = vscode.commands.registerCommand('jbspaceTodos.deleteTodo', (args) => todosCommands.deleteTodo(args));
-	const closeTodoCmd = vscode.commands.registerCommand('jbspaceTodos.markTodoClosed', (args) => todosCommands.markTodoClosed(args));
-	const openTodoCmd = vscode.commands.registerCommand('jbspaceTodos.markTodoOpen', (args) => todosCommands.markTodoOpen(args));
-	context.subscriptions.push(deleteTodoCmd);
-	context.subscriptions.push(closeTodoCmd);
-	context.subscriptions.push(openTodoCmd);
+	for (const command of vsCommands) {
+		context.subscriptions.push(command);
+	}
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,20 +25,20 @@ export function activate(context: vscode.ExtensionContext) {
 		todosProvider.refresh();
 	}
 
-	const setCredentialsCmd = vscode.commands.registerCommand('jbspace.setCredentials', async () => {
-		let url = await vscode.window.showInputBox({placeHolder: "ex. https://organization.jetbrains.space", prompt: "URL of your JB Space"});
-		const token = await vscode.window.showInputBox({placeHolder: "Token", prompt: "Enter/Paste your Token here"});
-		if(url !== undefined && token !== undefined) {
-			url = url.endsWith("/") ? (url + "api/http") : (url + "/api/http");
-			context.globalState.update('vscode-jb-space.url', url);
-			context.globalState.update('vscode-jb-space.token', token);
-			OpenAPI.BASE = url;
-			OpenAPI.TOKEN = token;
-			vscode.commands.executeCommand('setContext', 'jbspaceViewsConfig.showWelcome', false);
-			projectsProvider.refresh();
-			todosProvider.refresh();
-		}
-	});
+    const registerCommand = (name: string, fn: any, ...extraArgs: any[]) => {
+        console.log(`extra args: ${extraArgs}`)
+        return vscode.commands.registerCommand(
+            name,
+            (args) => fn(args, ...extraArgs)
+        )
+    }
+
+
+	const setCredentialsCmd = vscode.commands.registerCommand('jbspace.setCredentials', () => projectsCommands.setToken(context).then(() => {
+		projectsProvider.refresh();
+		todosProvider.refresh();
+	}));
+
 	context.subscriptions.push(setCredentialsCmd);
 
 	const refreshProjectsCmd = vscode.commands.registerCommand('jbspaceProjects.refreshProjects', () => projectsProvider.refresh());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,10 +47,12 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(createProjectCmd);
 
 	const createRepoCmd = vscode.commands.registerCommand('jbspaceProjects.createRepository', (args) => projectsCommands.createRepository(args));
-	const cloneRepoCmd = vscode.commands.registerCommand('jbspaceProjects.cloneRepository', (args) => projectsCommands.cloneRepository(args));
+	const cloneRepoWithHttpCmd = vscode.commands.registerCommand('jbspaceProjects.cloneRepositoryWithHttp', (args) => projectsCommands.cloneRepository(args));
+	const cloneRepoWithSshCmd = vscode.commands.registerCommand('jbspaceProjects.cloneRepositoryWithSsh', (args) => projectsCommands.cloneRepository(args, true));
 	const deleteRepoCmd = vscode.commands.registerCommand('jbspaceProjects.deleteRepository', (args) => projectsCommands.deleteRepository(args));
 	context.subscriptions.push(createRepoCmd);
-	context.subscriptions.push(cloneRepoCmd);
+	context.subscriptions.push(cloneRepoWithHttpCmd);
+	context.subscriptions.push(cloneRepoWithSshCmd);
 	context.subscriptions.push(deleteRepoCmd);
 
 	const createIssueCmd = vscode.commands.registerCommand('jbspaceProjects.createIssue', (args) => projectsCommands.createIssue(args));

--- a/src/modules/projects/commands.ts
+++ b/src/modules/projects/commands.ts
@@ -124,4 +124,21 @@ export default class ProjectCommands {
       vscode.window.showErrorMessage(e.message)
     }
   }
+
+  async setToken(context: vscode.ExtensionContext) {
+    let url = await vscode.window.showInputBox({
+      placeHolder: "ex. https://organization.jetbrains.space",
+      prompt: "URL of your JB Space"
+    });
+    const token = await vscode.window.showInputBox({placeHolder: "Token", prompt: "Enter/Paste your Token here"});
+    if (url !== undefined && token !== undefined) {
+      url = url.endsWith("/") ? (url + "api/http") : (url + "/api/http");
+      context.globalState.update('vscode-jb-space.url', url);
+      context.globalState.update('vscode-jb-space.token', token);
+      OpenAPI.BASE = url;
+      OpenAPI.TOKEN = token;
+      vscode.commands.executeCommand('setContext', 'jbspaceViewsConfig.showWelcome', false);
+    }
+  }
+
 }

--- a/src/modules/projects/commands.ts
+++ b/src/modules/projects/commands.ts
@@ -60,7 +60,7 @@ export default class ProjectCommands {
       const url = useSsh ? repositoryUrls.sshUrl : repositoryUrls.httpUrl;
       vscode.commands.executeCommand('git.clone', url)
     } catch (e) {
-      //Todo: add error handling/logging.
+      vscode.window.showErrorMessage(e.message);
     }
   }
 

--- a/src/modules/projects/commands.ts
+++ b/src/modules/projects/commands.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { IssueStatus, OpenAPI, ProjectKey, Service } from '../../api';
 import { ProjectsProvider } from './projects';
+import {RepositoryUrls} from "../../api/models/RepositoryUrls";
 
 export default class ProjectCommands {
 
@@ -40,9 +41,9 @@ export default class ProjectCommands {
       const defaultBranch = await vscode.window.showInputBox({placeHolder: "master", prompt: "Default branch (leave empty for master)"});
       if(!repositoryName) return;
       await Service.postService78(args.project.id, repositoryName, undefined, {
-        description: repositoryDescription, 
-        initialize: true, 
-        defaultBranch: defaultBranch, 
+        description: repositoryDescription,
+        initialize: true,
+        defaultBranch: defaultBranch,
         defaultSetup: true
       });
 
@@ -53,12 +54,14 @@ export default class ProjectCommands {
     }
   }
 
-  async cloneRepository(args: any) {
-    const companyName = OpenAPI.BASE.substr(0, OpenAPI.BASE.indexOf('.')).replace('https://', '').replace('http://', '');
-    const projectName = args.project.name.toLowerCase().split(" ").join("-");
-    const repositoryName = args.repository.name.toLowerCase().split(" ").join("-");
-    const url = `https://git.jetbrains.space/${companyName}/${projectName}/${repositoryName}.git`;
-    vscode.commands.executeCommand('git.clone', url);
+  async cloneRepository(args: any, useSsh:boolean = false) {
+    try {
+      const repositoryUrls = (await Service.getService163(args.project.id, args.repository.name) as RepositoryUrls);
+      const url = useSsh ? repositoryUrls.sshUrl : repositoryUrls.httpUrl;
+      vscode.commands.executeCommand('git.clone', url)
+    } catch (e) {
+      //Todo: add error handling/logging.
+    }
   }
 
   async deleteRepository(args: any) {

--- a/src/modules/projects/projects.ts
+++ b/src/modules/projects/projects.ts
@@ -7,7 +7,7 @@ import { ChecklistChildTreeItem, ChecklistTreeItem, IssueTreeItem, ProjectOption
 
 //TODO: add tree item commands
 export class ProjectsProvider implements vscode.TreeDataProvider<BasicTreeItem> {
-  
+
   private _onDidChangeTreeData: vscode.EventEmitter<BasicTreeItem | undefined | void> = new vscode.EventEmitter<BasicTreeItem | undefined | void>();
 	readonly onDidChangeTreeData: vscode.Event<BasicTreeItem | undefined | void> = this._onDidChangeTreeData.event;
 
@@ -25,8 +25,8 @@ export class ProjectsProvider implements vscode.TreeDataProvider<BasicTreeItem> 
     if(element === undefined) {
       return Service.getService57().then((value) => {
         return value.data.map((project) => new ProjectTreeItem(
-          project.name, 
-          project, 
+          project.name,
+          project,
           vscode.TreeItemCollapsibleState.Collapsed
         ));
       });
@@ -42,65 +42,69 @@ export class ProjectsProvider implements vscode.TreeDataProvider<BasicTreeItem> 
       });
     }
     //repository
-    else if(element.type === "repositories") {
-      if((element as ProjectOptionTreeItem).project.repos.length < 1) return Promise.resolve([new BasicTreeItem((element as ProjectOptionTreeItem).project.id + "-no-repositories", "No repositories", "no-result", vscode.TreeItemCollapsibleState.None)])
-      return Promise.resolve((element as ProjectOptionTreeItem).project.repos.map((repo) => new RepositoryTreeItem(
-        repo.name, 
-        (element as ProjectOptionTreeItem).project, 
-        repo, 
-        vscode.TreeItemCollapsibleState.None
-      )))
-    }
-    //checklists
-    else if(element.type === "checklists") {
-      return Service.getService93((element as ProjectOptionTreeItem).project.id, null, 100, null, ChecklistSorting.UPDATED, true).then((value) => {
-        if(value.data.length < 1) return Promise.resolve([new BasicTreeItem((element as ProjectOptionTreeItem).project.id + "-no-checklist", "Checklists empty", "no-result", vscode.TreeItemCollapsibleState.None)])
-        return value.data.map((checklist) => new ChecklistTreeItem(
-          checklist.name, 
-          (element as ProjectOptionTreeItem).project, 
-          checklist, 
-          vscode.TreeItemCollapsibleState.Collapsed
-        ));
-      });
-    }
-    else if(element.type === "checklist") {
-      return Service.getService95((element as ChecklistTreeItem).project.id, (element as ChecklistTreeItem).checklist.id, this.getChecklistFields(3)).then((value) => {
-        if((value as PlanItemChildren[]).length < 1) return Promise.resolve([new BasicTreeItem((element as ChecklistTreeItem).checklist.id + "-no-checklist-children", "No further checklists in tree", "no-result", vscode.TreeItemCollapsibleState.None)])
-        return (value as PlanItemChildren[]).pop()!.children.map((checklistChild) => new ChecklistChildTreeItem(
-          checklistChild.simpleText ?? checklistChild.id, 
-          (element as ChecklistTreeItem).project, 
-          checklistChild, 
-          checklistChild.children && checklistChild.children.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None
-        ));
-      });
-    }
-    else if(element.type === "checklistChild") {
-      return Promise.resolve((element as ChecklistChildTreeItem).checklistChild.children.map((checklistChild) => new ChecklistChildTreeItem(
-        checklistChild.simpleText ?? checklistChild.id, 
-        (element as ChecklistTreeItem).project, 
-        checklistChild, 
-        checklistChild.children && checklistChild.children.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None
-      )))
-    }
-    //issue
-    else if(element.type === "issues") {
-      //get statuses ids
-      return Service.getService98((element as ProjectOptionTreeItem).project.id).then((statuses) => {
-        //get issues
-        return Service.getService96((element as ProjectOptionTreeItem).project.id, [], (statuses as IssueStatus[]).map((status) => status.id), IssuesSorting.UPDATED, true).then((value) => {
-          if(value.data.length < 1) return Promise.resolve([new BasicTreeItem((element as ProjectOptionTreeItem).project.id + "-no-issues", "No issues", "no-result", vscode.TreeItemCollapsibleState.None)])
-          return value.data.map((issue) => new IssueTreeItem(
-            issue.title, 
-            (element as ProjectOptionTreeItem).project, 
-            issue, 
-            (statuses as IssueStatus[]), 
-            vscode.TreeItemCollapsibleState.None
-          ));
-        });
-      });
-    }
     else {
-      return Promise.resolve([]);
+      let project = (element as ProjectOptionTreeItem).project;
+
+      if(element.type === "repositories") {
+            if(project.repos.length < 1) return Promise.resolve([new BasicTreeItem(project.id + "-no-repositories", "No repositories", "no-result", vscode.TreeItemCollapsibleState.None)])
+            return Promise.resolve(project.repos.map((repo) => new RepositoryTreeItem(
+              repo.name,
+              project,
+              repo,
+              vscode.TreeItemCollapsibleState.None
+            )))
+          }
+          //checklists
+          else if(element.type === "checklists") {
+            return Service.getService93(project.id, null, 100, null, ChecklistSorting.UPDATED, true).then((value) => {
+              if(value.data.length < 1) return Promise.resolve([new BasicTreeItem(project.id + "-no-checklist", "Checklists empty", "no-result", vscode.TreeItemCollapsibleState.None)])
+              return value.data.map((checklist) => new ChecklistTreeItem(
+                checklist.name,
+                project,
+                checklist,
+                vscode.TreeItemCollapsibleState.Collapsed
+              ));
+            });
+          }
+          else if(element.type === "checklist") {
+            return Service.getService95((element as ChecklistTreeItem).project.id, (element as ChecklistTreeItem).checklist.id, this.getChecklistFields(3)).then((value) => {
+              if((value as PlanItemChildren[]).length < 1) return Promise.resolve([new BasicTreeItem((element as ChecklistTreeItem).checklist.id + "-no-checklist-children", "No further checklists in tree", "no-result", vscode.TreeItemCollapsibleState.None)])
+              return (value as PlanItemChildren[]).pop()!.children.map((checklistChild) => new ChecklistChildTreeItem(
+                checklistChild.simpleText ?? checklistChild.id,
+                (element as ChecklistTreeItem).project,
+                checklistChild,
+                checklistChild.children && checklistChild.children.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None
+              ));
+            });
+          }
+          else if(element.type === "checklistChild") {
+            return Promise.resolve((element as ChecklistChildTreeItem).checklistChild.children.map((checklistChild) => new ChecklistChildTreeItem(
+              checklistChild.simpleText ?? checklistChild.id,
+              (element as ChecklistTreeItem).project,
+              checklistChild,
+              checklistChild.children && checklistChild.children.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None
+            )))
+          }
+          //issue
+          else if(element.type === "issues") {
+            //get statuses ids
+            return Service.getService98(project.id).then((statuses) => {
+              //get issues
+              return Service.getService96(project.id, [], (statuses as IssueStatus[]).map((status) => status.id), IssuesSorting.UPDATED, true).then((value) => {
+                if(value.data.length < 1) return Promise.resolve([new BasicTreeItem(project.id + "-no-issues", "No issues", "no-result", vscode.TreeItemCollapsibleState.None)])
+                return value.data.map((issue) => new IssueTreeItem(
+                  issue.title,
+                  project,
+                  issue,
+                  (statuses as IssueStatus[]),
+                  vscode.TreeItemCollapsibleState.None
+                ));
+              });
+            });
+          }
+          else {
+            return Promise.resolve([]);
+          }
     }
   }
 


### PR DESCRIPTION
- Shim'd in support for SSH based cloning of git repos.  Supported this action by turning the 'clone' button on repository menu items in the tree into a sub-menu that prompts for the method to use (HTTP or SSH).
- Refactored the `cloneRepository` method to use the canonical repo url via an API request.
  - Manually created this method in `Service.ts` since I don't have guidance on re-generating the API wrapper.
- Refactored command registration to hopefully make it a little easier on the eyes.

