### PR TITLE
Ssh cloning

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"onView:jbspaceProjects"
 	],
 
-	
+
 	"contributes": {
 		"commands": [
 			{
@@ -72,14 +72,14 @@
 					"dark": "media/icons/plus-solid.svg"
 				}
 			},
-			{
-				"command": "jbspaceProjects.cloneRepository",
-				"title": "Clone Repository",
-				"icon": {
-					"light": "media/icons/cloud-download-alt-solid.svg",
-					"dark": "media/icons/cloud-download-alt-solid.svg"
-				}
-			},
+            {
+            "command": "jbspaceProjects.cloneRepositoryWithHttp",
+            "title": "Clone using Http"
+          },
+            {
+              "command": "jbspaceProjects.cloneRepositoryWithSsh",
+              "title": "Clone using SSH"
+            },
 			{
 				"command": "jbspaceProjects.deleteRepository",
 				"title": "Delete Repository",
@@ -161,6 +161,13 @@
 				}
 			}
 		],
+		"submenus": [
+			{
+				"id": "git.clone.submenu",
+				"label": "Clone Repository",
+				"icon": "media/icons/cloud-download-alt-solid.svg"
+			}
+		],
 		"menus": {
 			"view/title": [
 				{
@@ -190,11 +197,11 @@
 					"when": "view == jbspaceProjects && viewItem == repositories",
 					"group": "inline"
 				},
-				{
-					"command": "jbspaceProjects.cloneRepository",
-					"when": "view == jbspaceProjects && viewItem == repository",
-					"group": "inline"
-				},
+                {
+                "submenu": "git.clone.submenu",
+                "when": "view == jbspaceProjects && viewItem == repository",
+                "group": "inline"
+              },
 				{
 					"command": "jbspaceProjects.deleteRepository",
 					"when": "view == jbspaceProjects && viewItem == repository",
@@ -245,8 +252,21 @@
 					"when": "view == jbspaceTodos && viewItem == todo-closed",
 					"group": "inline"
 				}
+			],
+			"git.clone.submenu": [
+				{
+					"command": "jbspaceProjects.cloneRepositoryWithHttp",
+					"when": "view == jbspaceProjects && viewItem == repository",
+					"group": "inline"
+				},
+				{
+					"command": "jbspaceProjects.cloneRepositoryWithSsh",
+					"when": "view == jbspaceProjects && viewItem == repository",
+					"group": "inline"
+				}
 			]
 		},
+
 		"viewsWelcome": [
 			{
 				"view": "jbspaceWelcome",

--- a/src/api/models/RepositoryUrls.ts
+++ b/src/api/models/RepositoryUrls.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type RepositoryUrls = {
+    httpUrl: string | null;
+    sshHost: string | null;
+    sshUrl: string | null;
+}

--- a/src/api/services/Service.ts
+++ b/src/api/services/Service.ts
@@ -172,6 +172,7 @@ import type { VcsHostingPassword } from '../models/VcsHostingPassword';
 import type { Weekday } from '../models/Weekday';
 import type { WorkingDaysSpec } from '../models/WorkingDaysSpec';
 import { request as __request } from '../core/request';
+import {RepositoryUrls} from "../models/RepositoryUrls";
 
 export class Service {
 
@@ -11596,6 +11597,29 @@ export class Service {
                 '$fields': fields,
             },
         });
+        return result.body;
+    }
+
+    /**
+     * Get repository url
+     * @param projectId
+     * @param repositoryName
+     * @result RepositoryUrls
+     * @result any Error
+     * @throws ApiError
+     */
+    public static async getService163(
+        projectId: string,
+        repositoryName: string
+    ): Promise<RepositoryUrls | {
+        error: string,
+        error_description: string
+    }> {
+        const result = await __request({
+            method: 'GET',
+            path: `/projects/${projectId}/repositories/${repositoryName}/url`,
+        });
+
         return result.body;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,10 +26,10 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 
 	const registerCommand = (name: string, fn: any, ...extraArgs: any[]) =>
-		vscode.commands.registerCommand(name, (args) => fn(args, ...extraArgs))
+		vscode.commands.registerCommand(name, (args) => fn(args, ...extraArgs), fn)
 
 	const vsCommands = [
-		registerCommand('jbspace.setCredentials', () => projectsCommands.setToken(context).then(() => {
+		registerCommand('jbspace.setCredentials', async () => projectsCommands.setToken(context).then(() => {
 			projectsProvider.refresh();
 			todosProvider.refresh();
 		})),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { OpenAPI } from './api/index';
+import { OpenAPI } from './api';
 import { ProjectsProvider } from './modules/projects/projects';
 import ProjectCommands from './modules/projects/commands';
 import { TodosProvider } from './modules/todos/todos';
@@ -56,11 +56,9 @@ export function activate(context: vscode.ExtensionContext) {
 		registerCommand('jbspaceTodos.deleteTodo', todosCommands.deleteTodo),
 		registerCommand('jbspaceTodos.markTodoClosed', todosCommands.markTodoClosed),
 		registerCommand('jbspaceTodos.markTodoOpen', todosCommands.markTodoOpen),
-	];
+	]
 
-	for (const command of vsCommands) {
-		context.subscriptions.push(command);
-	}
+	vsCommands.map((command) => context.subscriptions.push(command));
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,57 +25,42 @@ export function activate(context: vscode.ExtensionContext) {
 		todosProvider.refresh();
 	}
 
-    const registerCommand = (name: string, fn: any, ...extraArgs: any[]) => {
-        console.log(`extra args: ${extraArgs}`)
-        return vscode.commands.registerCommand(
-            name,
-            (args) => fn(args, ...extraArgs)
-        )
-    }
+	const registerCommand = (name: string, fn: any, ...extraArgs: any[]) =>
+		vscode.commands.registerCommand(name, (args) => fn(args, ...extraArgs))
 
+	const vsCommands = [
+		registerCommand('jbspace.setCredentials', () => projectsCommands.setToken(context).then(() => {
+			projectsProvider.refresh();
+			todosProvider.refresh();
+		})),
 
-	const setCredentialsCmd = vscode.commands.registerCommand('jbspace.setCredentials', () => projectsCommands.setToken(context).then(() => {
-		projectsProvider.refresh();
-		todosProvider.refresh();
-	}));
+		// Project commands
+		registerCommand('jbspaceProjects.refreshProjects', projectsProvider.refresh),
+		registerCommand('jbspaceProjects.createProject', projectsCommands.createProject),
 
-	context.subscriptions.push(setCredentialsCmd);
+		// Repository commands
+		registerCommand('jbspaceProjects.createRepository', projectsCommands.createRepository),
+		registerCommand('jbspaceProjects.cloneRepositoryWithHttp', projectsCommands.cloneRepository),
+		registerCommand('jbspaceProjects.cloneRepositoryWithSsh', projectsCommands.cloneRepository, true),
+		registerCommand('jbspaceProjects.deleteRepository', projectsCommands.deleteRepository),
 
-	const refreshProjectsCmd = vscode.commands.registerCommand('jbspaceProjects.refreshProjects', () => projectsProvider.refresh());
-	const createProjectCmd = vscode.commands.registerCommand('jbspaceProjects.createProject', (args) => projectsCommands.createProject(args));
-	context.subscriptions.push(refreshProjectsCmd);
-	context.subscriptions.push(createProjectCmd);
+		// Issues commands
+		registerCommand('jbspaceProjects.createIssue', projectsCommands.createIssue),
+		registerCommand('jbspaceProjects.markIssueResolved', projectsCommands.markIssueResolved, true),
+		registerCommand('jbspaceProjects.markIssueUnresolved', projectsCommands.markIssueResolved, false),
+		registerCommand('jbspaceProjects.deleteIssue', projectsCommands.deleteIssue),
 
-	const createRepoCmd = vscode.commands.registerCommand('jbspaceProjects.createRepository', (args) => projectsCommands.createRepository(args));
-	const cloneRepoWithHttpCmd = vscode.commands.registerCommand('jbspaceProjects.cloneRepositoryWithHttp', (args) => projectsCommands.cloneRepository(args));
-	const cloneRepoWithSshCmd = vscode.commands.registerCommand('jbspaceProjects.cloneRepositoryWithSsh', (args) => projectsCommands.cloneRepository(args, true));
-	const deleteRepoCmd = vscode.commands.registerCommand('jbspaceProjects.deleteRepository', (args) => projectsCommands.deleteRepository(args));
-	context.subscriptions.push(createRepoCmd);
-	context.subscriptions.push(cloneRepoWithHttpCmd);
-	context.subscriptions.push(cloneRepoWithSshCmd);
-	context.subscriptions.push(deleteRepoCmd);
+		// Todos commands
+		registerCommand('jbspaceTodos.refreshTodos', todosProvider.refresh),
+		registerCommand('jbspaceTodos.createTodo', todosCommands.createTodo),
+		registerCommand('jbspaceTodos.deleteTodo', todosCommands.deleteTodo),
+		registerCommand('jbspaceTodos.markTodoClosed', todosCommands.markTodoClosed),
+		registerCommand('jbspaceTodos.markTodoOpen', todosCommands.markTodoOpen),
+	];
 
-	const createIssueCmd = vscode.commands.registerCommand('jbspaceProjects.createIssue', (args) => projectsCommands.createIssue(args));
-	const resolveIssueCmd = vscode.commands.registerCommand('jbspaceProjects.markIssueResolved', (args) => projectsCommands.markIssueResolved(args, true));
-	const unresolveIssueCmd = vscode.commands.registerCommand('jbspaceProjects.markIssueUnresolved', (args) => projectsCommands.markIssueResolved(args, false));
-	const deleteIssueCmd = vscode.commands.registerCommand('jbspaceProjects.deleteIssue', (args) => projectsCommands.deleteIssue(args));
-	context.subscriptions.push(createIssueCmd);
-	context.subscriptions.push(resolveIssueCmd);
-	context.subscriptions.push(unresolveIssueCmd);
-	context.subscriptions.push(deleteIssueCmd);
-
-
-	const refreshTodosCmd = vscode.commands.registerCommand('jbspaceTodos.refreshTodos', () => todosProvider.refresh());
-	const createTodoCmd = vscode.commands.registerCommand('jbspaceTodos.createTodo', (args) => todosCommands.createTodo(args));
-	context.subscriptions.push(refreshTodosCmd);
-	context.subscriptions.push(createTodoCmd);
-
-	const deleteTodoCmd = vscode.commands.registerCommand('jbspaceTodos.deleteTodo', (args) => todosCommands.deleteTodo(args));
-	const closeTodoCmd = vscode.commands.registerCommand('jbspaceTodos.markTodoClosed', (args) => todosCommands.markTodoClosed(args));
-	const openTodoCmd = vscode.commands.registerCommand('jbspaceTodos.markTodoOpen', (args) => todosCommands.markTodoOpen(args));
-	context.subscriptions.push(deleteTodoCmd);
-	context.subscriptions.push(closeTodoCmd);
-	context.subscriptions.push(openTodoCmd);
+	for (const command of vsCommands) {
+		context.subscriptions.push(command);
+	}
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,20 +25,20 @@ export function activate(context: vscode.ExtensionContext) {
 		todosProvider.refresh();
 	}
 
-	const setCredentialsCmd = vscode.commands.registerCommand('jbspace.setCredentials', async () => {
-		let url = await vscode.window.showInputBox({placeHolder: "ex. https://organization.jetbrains.space", prompt: "URL of your JB Space"});
-		const token = await vscode.window.showInputBox({placeHolder: "Token", prompt: "Enter/Paste your Token here"});
-		if(url !== undefined && token !== undefined) {
-			url = url.endsWith("/") ? (url + "api/http") : (url + "/api/http");
-			context.globalState.update('vscode-jb-space.url', url);
-			context.globalState.update('vscode-jb-space.token', token);
-			OpenAPI.BASE = url;
-			OpenAPI.TOKEN = token;
-			vscode.commands.executeCommand('setContext', 'jbspaceViewsConfig.showWelcome', false);
-			projectsProvider.refresh();
-			todosProvider.refresh();
-		}
-	});
+    const registerCommand = (name: string, fn: any, ...extraArgs: any[]) => {
+        console.log(`extra args: ${extraArgs}`)
+        return vscode.commands.registerCommand(
+            name,
+            (args) => fn(args, ...extraArgs)
+        )
+    }
+
+
+	const setCredentialsCmd = vscode.commands.registerCommand('jbspace.setCredentials', () => projectsCommands.setToken(context).then(() => {
+		projectsProvider.refresh();
+		todosProvider.refresh();
+	}));
+
 	context.subscriptions.push(setCredentialsCmd);
 
 	const refreshProjectsCmd = vscode.commands.registerCommand('jbspaceProjects.refreshProjects', () => projectsProvider.refresh());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,10 +47,12 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(createProjectCmd);
 
 	const createRepoCmd = vscode.commands.registerCommand('jbspaceProjects.createRepository', (args) => projectsCommands.createRepository(args));
-	const cloneRepoCmd = vscode.commands.registerCommand('jbspaceProjects.cloneRepository', (args) => projectsCommands.cloneRepository(args));
+	const cloneRepoWithHttpCmd = vscode.commands.registerCommand('jbspaceProjects.cloneRepositoryWithHttp', (args) => projectsCommands.cloneRepository(args));
+	const cloneRepoWithSshCmd = vscode.commands.registerCommand('jbspaceProjects.cloneRepositoryWithSsh', (args) => projectsCommands.cloneRepository(args, true));
 	const deleteRepoCmd = vscode.commands.registerCommand('jbspaceProjects.deleteRepository', (args) => projectsCommands.deleteRepository(args));
 	context.subscriptions.push(createRepoCmd);
-	context.subscriptions.push(cloneRepoCmd);
+	context.subscriptions.push(cloneRepoWithHttpCmd);
+	context.subscriptions.push(cloneRepoWithSshCmd);
 	context.subscriptions.push(deleteRepoCmd);
 
 	const createIssueCmd = vscode.commands.registerCommand('jbspaceProjects.createIssue', (args) => projectsCommands.createIssue(args));

--- a/src/modules/projects/commands.ts
+++ b/src/modules/projects/commands.ts
@@ -10,7 +10,7 @@ export default class ProjectCommands {
     this.projectProvider = projectProvider;
   }
 
-  async createProject() {
+  createProject = async () => {
     try {
       const projectKey = await vscode.window.showInputBox({placeHolder: "Key", prompt: "Enter Project Key"});
       const projectName = await vscode.window.showInputBox({placeHolder: "Name", prompt: "The name of the project"});
@@ -34,7 +34,7 @@ export default class ProjectCommands {
     }
   }
 
-  async createRepository(args: any) {
+  createRepository = async (args: any) => {
     try {
       const repositoryName = await vscode.window.showInputBox({placeHolder: "Name", prompt: "The name of the repository"});
       const repositoryDescription = await vscode.window.showInputBox({placeHolder: "Description", prompt: "Decription of the repository (can be empty)"});
@@ -54,7 +54,7 @@ export default class ProjectCommands {
     }
   }
 
-  async cloneRepository(args: any, useSsh:boolean = false) {
+  cloneRepository = async (args: any, useSsh:boolean = false) => {
     try {
       const repositoryUrls = (await Service.getService163(args.project.id, args.repository.name) as RepositoryUrls);
       const url = useSsh ? repositoryUrls.sshUrl : repositoryUrls.httpUrl;
@@ -64,7 +64,7 @@ export default class ProjectCommands {
     }
   }
 
-  async deleteRepository(args: any) {
+  deleteRepository = async (args: any) => {
     try {
       const confirmation = await vscode.window.showQuickPick(["Yes", "No"], {placeHolder: "Are you sure you want to delete this repository?", canPickMany: false});
       if(!confirmation || confirmation === "No" || confirmation !== "Yes") return;
@@ -78,7 +78,7 @@ export default class ProjectCommands {
     }
   }
 
-  async createIssue(args: any) {
+  createIssue = async (args: any) => {
     try {
       const statuses = await Service.getService98(args.project.id);
       const title = await vscode.window.showInputBox({placeHolder: "Title", prompt: "The title of the issue"});
@@ -100,7 +100,7 @@ export default class ProjectCommands {
     }
   }
 
-  async markIssueResolved(args: any, resolved: boolean) {
+  markIssueResolved = async (args: any, resolved: boolean) => {
     try {
       await Service.postService72(args.project.id, args.issue.id, {resolved: resolved});
 
@@ -111,7 +111,7 @@ export default class ProjectCommands {
     }
   }
 
-  async deleteIssue(args: any) {
+  deleteIssue = async (args: any) => {
     //TODO: show are you sure dialog
     try {
       const confirmation = await vscode.window.showQuickPick(["Yes", "No"], {placeHolder: "Are you sure you want to delete this issue?", canPickMany: false});
@@ -125,7 +125,7 @@ export default class ProjectCommands {
     }
   }
 
-  async setToken(context: vscode.ExtensionContext) {
+  setToken = async (context: vscode.ExtensionContext) => {
     let url = await vscode.window.showInputBox({
       placeHolder: "ex. https://organization.jetbrains.space",
       prompt: "URL of your JB Space"
@@ -139,5 +139,6 @@ export default class ProjectCommands {
       OpenAPI.TOKEN = token;
       vscode.commands.executeCommand('setContext', 'jbspaceViewsConfig.showWelcome', false);
     }
+
   }
 }

--- a/src/modules/projects/commands.ts
+++ b/src/modules/projects/commands.ts
@@ -124,4 +124,21 @@ export default class ProjectCommands {
       vscode.window.showErrorMessage(e.message)
     }
   }
+
+  async setToken(context: vscode.ExtensionContext) {
+    let url = await vscode.window.showInputBox({
+      placeHolder: "ex. https://organization.jetbrains.space",
+      prompt: "URL of your JB Space"
+    });
+    const token = await vscode.window.showInputBox({placeHolder: "Token", prompt: "Enter/Paste your Token here"});
+    if (url !== undefined && token !== undefined) {
+      url = url.endsWith("/") ? (url + "api/http") : (url + "/api/http");
+      context.globalState.update('vscode-jb-space.url', url);
+      context.globalState.update('vscode-jb-space.token', token);
+      OpenAPI.BASE = url;
+      OpenAPI.TOKEN = token;
+      vscode.commands.executeCommand('setContext', 'jbspaceViewsConfig.showWelcome', false);
+    }
+  }
+
 }

--- a/src/modules/projects/commands.ts
+++ b/src/modules/projects/commands.ts
@@ -60,7 +60,7 @@ export default class ProjectCommands {
       const url = useSsh ? repositoryUrls.sshUrl : repositoryUrls.httpUrl;
       vscode.commands.executeCommand('git.clone', url)
     } catch (e) {
-      //Todo: add error handling/logging.
+      vscode.window.showErrorMessage(e.message);
     }
   }
 

--- a/src/modules/projects/commands.ts
+++ b/src/modules/projects/commands.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { IssueStatus, OpenAPI, ProjectKey, Service } from '../../api';
-import { ProjectsProvider } from './projects';
+import {IssueStatus, OpenAPI, Service} from '../../api';
+import {ProjectsProvider} from './projects';
 import {RepositoryUrls} from "../../api/models/RepositoryUrls";
 
 export default class ProjectCommands {
@@ -10,7 +10,7 @@ export default class ProjectCommands {
     this.projectProvider = projectProvider;
   }
 
-  async createProject(args: any) {
+  async createProject() {
     try {
       const projectKey = await vscode.window.showInputBox({placeHolder: "Key", prompt: "Enter Project Key"});
       const projectName = await vscode.window.showInputBox({placeHolder: "Name", prompt: "The name of the project"});
@@ -23,7 +23,7 @@ export default class ProjectCommands {
         key: {key: projectKey},
         name: projectName,
         description: projectDescription,
-        private: isPrivate === "Yes" ? true : false,
+        private: isPrivate === "Yes",
         tags: tags ? tags.split(",") : undefined
       });
 
@@ -140,5 +140,4 @@ export default class ProjectCommands {
       vscode.commands.executeCommand('setContext', 'jbspaceViewsConfig.showWelcome', false);
     }
   }
-
 }

--- a/src/modules/projects/commands.ts
+++ b/src/modules/projects/commands.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { IssueStatus, OpenAPI, ProjectKey, Service } from '../../api';
 import { ProjectsProvider } from './projects';
+import {RepositoryUrls} from "../../api/models/RepositoryUrls";
 
 export default class ProjectCommands {
 
@@ -40,9 +41,9 @@ export default class ProjectCommands {
       const defaultBranch = await vscode.window.showInputBox({placeHolder: "master", prompt: "Default branch (leave empty for master)"});
       if(!repositoryName) return;
       await Service.postService78(args.project.id, repositoryName, undefined, {
-        description: repositoryDescription, 
-        initialize: true, 
-        defaultBranch: defaultBranch, 
+        description: repositoryDescription,
+        initialize: true,
+        defaultBranch: defaultBranch,
         defaultSetup: true
       });
 
@@ -53,12 +54,14 @@ export default class ProjectCommands {
     }
   }
 
-  async cloneRepository(args: any) {
-    const companyName = OpenAPI.BASE.substr(0, OpenAPI.BASE.indexOf('.')).replace('https://', '').replace('http://', '');
-    const projectName = args.project.name.toLowerCase().split(" ").join("-");
-    const repositoryName = args.repository.name.toLowerCase().split(" ").join("-");
-    const url = `https://git.jetbrains.space/${companyName}/${projectName}/${repositoryName}.git`;
-    vscode.commands.executeCommand('git.clone', url);
+  async cloneRepository(args: any, useSsh:boolean = false) {
+    try {
+      const repositoryUrls = (await Service.getService163(args.project.id, args.repository.name) as RepositoryUrls);
+      const url = useSsh ? repositoryUrls.sshUrl : repositoryUrls.httpUrl;
+      vscode.commands.executeCommand('git.clone', url)
+    } catch (e) {
+      //Todo: add error handling/logging.
+    }
   }
 
   async deleteRepository(args: any) {

--- a/src/modules/projects/models.ts
+++ b/src/modules/projects/models.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import BasicTreeItem from '../core/models';
-import { Checklist, Issue, IssueStatus, PlanItem, PR_Project, PR_RepositoryInfo } from '../../api/index';
+import {Checklist, Issue, IssueStatus, PlanItem, PR_Project, PR_RepositoryInfo} from '../../api';
 
 export class ProjectTreeItem extends BasicTreeItem {
   constructor(
@@ -85,8 +85,8 @@ export class IssueTreeItem extends BasicTreeItem {
   ) {
     super(issue.id, label, "issue", collapsibleState);
   }
-  iconPath = this.isResolved 
-    ? path.join(__filename, '..', '..', 'media', 'icons', 'check-circle.svg') 
+  iconPath = this.isResolved
+    ? path.join(__filename, '..', '..', 'media', 'icons', 'check-circle.svg')
     : path.join(__filename, '..', '..', 'media', 'icons', 'circle.svg')
   contextValue = "issue-" + (this.isResolved ? "resolved" : "unresolved");
 

--- a/src/modules/projects/projects.ts
+++ b/src/modules/projects/projects.ts
@@ -1,9 +1,15 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import BasicTreeItem from '../core/models';
-import { Service } from '../../api';
-import { ChecklistSorting, IssuesSorting, IssueStatus, OpenAPI, PlanItemChildren, PR_Project } from '../../api';
-import { ChecklistChildTreeItem, ChecklistTreeItem, IssueTreeItem, ProjectOptionTreeItem, ProjectTreeItem, RepositoryTreeItem } from './models';
+import {ChecklistSorting, IssuesSorting, IssueStatus, OpenAPI, PlanItemChildren, PR_Project, Service} from '../../api';
+import {
+  ChecklistChildTreeItem,
+  ChecklistTreeItem,
+  IssueTreeItem,
+  ProjectOptionTreeItem,
+  ProjectTreeItem,
+  RepositoryTreeItem
+} from './models';
 
 //TODO: add tree item commands
 export class ProjectsProvider implements vscode.TreeDataProvider<BasicTreeItem> {

--- a/src/modules/projects/projects.ts
+++ b/src/modules/projects/projects.ts
@@ -109,7 +109,7 @@ export class ProjectsProvider implements vscode.TreeDataProvider<BasicTreeItem> 
     }
   }
 
-  getChecklistFields(depth: number): string {
+  getChecklistFields = (depth: number): string => {
     return `children(issue,id,checklistId,hasChildren,simpleDone,simpleText,${(depth === 0 ? "children" : this.getChecklistFields(depth -1))})`;
   }
 }

--- a/src/modules/projects/projects.ts
+++ b/src/modules/projects/projects.ts
@@ -1,20 +1,19 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import BasicTreeItem from '../core/models';
-import { Service } from '../../api/services/Service';
-import { ChecklistSorting, IssuesSorting, IssueStatus, OpenAPI, PlanItemChildren, PR_Project } from '../../api/index';
+import { Service } from '../../api';
+import { ChecklistSorting, IssuesSorting, IssueStatus, OpenAPI, PlanItemChildren, PR_Project } from '../../api';
 import { ChecklistChildTreeItem, ChecklistTreeItem, IssueTreeItem, ProjectOptionTreeItem, ProjectTreeItem, RepositoryTreeItem } from './models';
 
 //TODO: add tree item commands
 export class ProjectsProvider implements vscode.TreeDataProvider<BasicTreeItem> {
-  
+
   private _onDidChangeTreeData: vscode.EventEmitter<BasicTreeItem | undefined | void> = new vscode.EventEmitter<BasicTreeItem | undefined | void>();
-	readonly onDidChangeTreeData: vscode.Event<BasicTreeItem | undefined | void> = this._onDidChangeTreeData.event;
+  readonly onDidChangeTreeData: vscode.Event<BasicTreeItem | undefined | void> = this._onDidChangeTreeData.event;
 
-  refresh(): void {
-		this._onDidChangeTreeData.fire();
-	}
-
+  refresh = (): void => {
+    this._onDidChangeTreeData.fire();
+  }
   getTreeItem(element: BasicTreeItem): vscode.TreeItem {
     return element;
   }
@@ -25,8 +24,8 @@ export class ProjectsProvider implements vscode.TreeDataProvider<BasicTreeItem> 
     if(element === undefined) {
       return Service.getService57().then((value) => {
         return value.data.map((project) => new ProjectTreeItem(
-          project.name, 
-          project, 
+          project.name,
+          project,
           vscode.TreeItemCollapsibleState.Collapsed
         ));
       });
@@ -45,9 +44,9 @@ export class ProjectsProvider implements vscode.TreeDataProvider<BasicTreeItem> 
     else if(element.type === "repositories") {
       if((element as ProjectOptionTreeItem).project.repos.length < 1) return Promise.resolve([new BasicTreeItem((element as ProjectOptionTreeItem).project.id + "-no-repositories", "No repositories", "no-result", vscode.TreeItemCollapsibleState.None)])
       return Promise.resolve((element as ProjectOptionTreeItem).project.repos.map((repo) => new RepositoryTreeItem(
-        repo.name, 
-        (element as ProjectOptionTreeItem).project, 
-        repo, 
+        repo.name,
+        (element as ProjectOptionTreeItem).project,
+        repo,
         vscode.TreeItemCollapsibleState.None
       )))
     }
@@ -56,9 +55,9 @@ export class ProjectsProvider implements vscode.TreeDataProvider<BasicTreeItem> 
       return Service.getService93((element as ProjectOptionTreeItem).project.id, null, 100, null, ChecklistSorting.UPDATED, true).then((value) => {
         if(value.data.length < 1) return Promise.resolve([new BasicTreeItem((element as ProjectOptionTreeItem).project.id + "-no-checklist", "Checklists empty", "no-result", vscode.TreeItemCollapsibleState.None)])
         return value.data.map((checklist) => new ChecklistTreeItem(
-          checklist.name, 
-          (element as ProjectOptionTreeItem).project, 
-          checklist, 
+          checklist.name,
+          (element as ProjectOptionTreeItem).project,
+          checklist,
           vscode.TreeItemCollapsibleState.Collapsed
         ));
       });
@@ -67,18 +66,18 @@ export class ProjectsProvider implements vscode.TreeDataProvider<BasicTreeItem> 
       return Service.getService95((element as ChecklistTreeItem).project.id, (element as ChecklistTreeItem).checklist.id, this.getChecklistFields(3)).then((value) => {
         if((value as PlanItemChildren[]).length < 1) return Promise.resolve([new BasicTreeItem((element as ChecklistTreeItem).checklist.id + "-no-checklist-children", "No further checklists in tree", "no-result", vscode.TreeItemCollapsibleState.None)])
         return (value as PlanItemChildren[]).pop()!.children.map((checklistChild) => new ChecklistChildTreeItem(
-          checklistChild.simpleText ?? checklistChild.id, 
-          (element as ChecklistTreeItem).project, 
-          checklistChild, 
+          checklistChild.simpleText ?? checklistChild.id,
+          (element as ChecklistTreeItem).project,
+          checklistChild,
           checklistChild.children && checklistChild.children.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None
         ));
       });
     }
     else if(element.type === "checklistChild") {
       return Promise.resolve((element as ChecklistChildTreeItem).checklistChild.children.map((checklistChild) => new ChecklistChildTreeItem(
-        checklistChild.simpleText ?? checklistChild.id, 
-        (element as ChecklistTreeItem).project, 
-        checklistChild, 
+        checklistChild.simpleText ?? checklistChild.id,
+        (element as ChecklistTreeItem).project,
+        checklistChild,
         checklistChild.children && checklistChild.children.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None
       )))
     }
@@ -90,10 +89,10 @@ export class ProjectsProvider implements vscode.TreeDataProvider<BasicTreeItem> 
         return Service.getService96((element as ProjectOptionTreeItem).project.id, [], (statuses as IssueStatus[]).map((status) => status.id), IssuesSorting.UPDATED, true).then((value) => {
           if(value.data.length < 1) return Promise.resolve([new BasicTreeItem((element as ProjectOptionTreeItem).project.id + "-no-issues", "No issues", "no-result", vscode.TreeItemCollapsibleState.None)])
           return value.data.map((issue) => new IssueTreeItem(
-            issue.title, 
-            (element as ProjectOptionTreeItem).project, 
-            issue, 
-            (statuses as IssueStatus[]), 
+            issue.title,
+            (element as ProjectOptionTreeItem).project,
+            issue,
+            (statuses as IssueStatus[]),
             vscode.TreeItemCollapsibleState.None
           ));
         });
@@ -108,6 +107,3 @@ export class ProjectsProvider implements vscode.TreeDataProvider<BasicTreeItem> 
     return `children(issue,id,checklistId,hasChildren,simpleDone,simpleText,${(depth === 0 ? "children" : this.getChecklistFields(depth -1))})`;
   }
 }
-
-
-

--- a/src/modules/todos/commands.ts
+++ b/src/modules/todos/commands.ts
@@ -9,7 +9,7 @@ export default class TodoCommands {
     this.todosProvider = todosProvider;
   }
 
-  async createTodo() {
+  createTodo = async () => {
     try {
       const text = await vscode.window.showInputBox({placeHolder: "Text", prompt: "Enter TO-DO text"});
       const dueDate = await vscode.window.showInputBox({value: this._formatDate(new Date()), prompt: "Due date (optional)"});
@@ -27,7 +27,7 @@ export default class TodoCommands {
     }
   }
 
-  async deleteTodo(args: any) {
+  deleteTodo = async (args: any) => {
     try {
       const confirmation = await vscode.window.showQuickPick(["Yes", "No"], {placeHolder: "Are you sure you want to delete this TO-DO?", canPickMany: false});
       if(!confirmation || confirmation === "No" || confirmation !== "Yes") return;
@@ -41,7 +41,7 @@ export default class TodoCommands {
     }
   }
 
-  async markTodoClosed(args: any) {
+  markTodoClosed = async (args: any) => {
     try {
       await Service.patchService49(args.todo.id, {open: false});
 
@@ -52,7 +52,7 @@ export default class TodoCommands {
     }
   }
 
-  async markTodoOpen(args: any) {
+  markTodoOpen = async (args: any) => {
     try {
       await Service.patchService49(args.todo.id, {open: true});
 
@@ -63,7 +63,7 @@ export default class TodoCommands {
     }
   }
 
-  _formatDate(date: Date): string {
+  _formatDate = (date: Date): string => {
     let year: string = date.getFullYear().toString();
     let month: string = (date.getMonth() + 1).toString(); month = parseInt(month) > 9 ? month : ("0" + month);
     let day: string = date.getDate() > 9 ? date.getDate().toString() : ("0" + date.getDate());

--- a/src/modules/todos/commands.ts
+++ b/src/modules/todos/commands.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { OpenAPI, Service } from '../../api';
-import { TodosProvider } from './todos';
+import {Service} from '../../api';
+import {TodosProvider} from './todos';
 
 export default class TodoCommands {
 
@@ -9,7 +9,7 @@ export default class TodoCommands {
     this.todosProvider = todosProvider;
   }
 
-  async createTodo(args: any) {
+  async createTodo() {
     try {
       const text = await vscode.window.showInputBox({placeHolder: "Text", prompt: "Enter TO-DO text"});
       const dueDate = await vscode.window.showInputBox({value: this._formatDate(new Date()), prompt: "Due date (optional)"});

--- a/src/modules/todos/models.ts
+++ b/src/modules/todos/models.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { TodoItemRecord } from '../../api/models/TodoItemRecord';
+import {TodoContent, TodoItemRecord} from '../../api';
 import BasicTreeItem from '../core/models';
-import { TodoContent } from '../../api';
 
 export class TodoTreeItem extends BasicTreeItem {
   constructor(
@@ -11,7 +10,7 @@ export class TodoTreeItem extends BasicTreeItem {
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,
   ) {
     super(todo.id, label, "todo", collapsibleState);
-    
+
     const kind = (this.todo.content as TodoContent).kind;
     switch(kind) {
       case "REGULAR": this.label = "📝 - " + this.label; break;
@@ -19,8 +18,8 @@ export class TodoTreeItem extends BasicTreeItem {
       case "ISSUE": this.label = "🐞 - " + this.label; break;
     }
   }
-  iconPath = !this.isOpen 
-    ? path.join(__filename, '..', '..', 'media', 'icons', 'check-circle.svg') 
+  iconPath = !this.isOpen
+    ? path.join(__filename, '..', '..', 'media', 'icons', 'check-circle.svg')
     : path.join(__filename, '..', '..', 'media', 'icons', 'circle.svg')
   contextValue = "todo-" + (this.isOpen ? "open" : "closed")
 

--- a/src/modules/todos/todos.ts
+++ b/src/modules/todos/todos.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode';
 import BasicTreeItem from '../core/models';
-import { OpenAPI } from '../../api/core/OpenAPI';
-import { Service } from '../../api/services/Service';
-import { TodoTreeItem } from './models';
+import {OpenAPI, Service} from '../../api';
+import {TodoTreeItem} from './models';
 
 export class TodosProvider implements vscode.TreeDataProvider<BasicTreeItem> {
 
@@ -16,14 +15,14 @@ export class TodosProvider implements vscode.TreeDataProvider<BasicTreeItem> {
   getTreeItem(element: BasicTreeItem): vscode.TreeItem {
     return element;
   }
-  
+
   getChildren(element?: BasicTreeItem): Thenable<BasicTreeItem[]> {
     if(OpenAPI.TOKEN === undefined) return Promise.resolve([]);
     if(element === undefined) {
       return Service.getService158().then((value) => {
         let todos = value.data.map((todo) => new TodoTreeItem(
-          todo.content.text, 
-          todo, 
+          todo.content.text,
+          todo,
           vscode.TreeItemCollapsibleState.None
         ));
         todos.sort((a, b) => {


### PR DESCRIPTION
- Shim'd in support for SSH based cloning of git repos. Supported this action by turning the 'clone' button on repository menu items in the tree into a sub-menu that prompts for the method to use (HTTP or SSH).
- Refactored the cloneRepository method to use the canonical repo url via an API request.
- Manually created this method in Service.ts since I don't have guidance on re-generating the API wrapper.
- Refactored command registration to hopefully make it a little easier on the eyes.
 
This PR addresses issue #6 as well as a bug that can cause the wrong url to be used during the repo cloning process.  Open to suggestions re the UI approach, but it seemed the most appropriate given the amount of space available.